### PR TITLE
feat(dashboard): migrate to session auth + e2e helpers

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -6,6 +6,22 @@ This template provides a minimal setup to get React working in Vite with HMR and
 
 - `VITE_API_BASE_URL` (optional): API base URL for the dashboard (defaults to same origin).
 
+## E2E Env
+
+Playwright e2e auth uses Better Auth session login through `/sign-in` (no `/api/auth/login` dependency).
+
+- `E2E_ADMIN_EMAIL` (required): admin user email for e2e sign-in.
+- `E2E_ADMIN_PASSWORD` (required): admin user password for e2e sign-in.
+- `DASHBOARD_BASE_URL` (optional): dashboard URL for Playwright (defaults to `http://localhost:5173`).
+- `E2E_API_BASE_URL` (optional): API URL used by e2e request helpers (defaults to `http://localhost:3000`).
+- `API_SECRET` or `CLOUDINARY_API_SECRET` (required for webhook-related specs only).
+
+Run e2e:
+
+```bash
+pnpm -C dashboard test:e2e
+```
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/dashboard/e2e/auth-session.spec.ts
+++ b/dashboard/e2e/auth-session.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { adminCredentialsMissing, signInAsAdmin } from './helpers/auth';
+
+test.describe('Auth session guard', () => {
+  test.skip(adminCredentialsMissing, 'Missing admin credentials');
+
+  test('redirects to /sign-in after session becomes invalid', async ({
+    context,
+    page,
+  }) => {
+    await signInAsAdmin(page);
+    await page.goto('/images');
+    await expect(page).not.toHaveURL(/\/sign-in$/);
+
+    await context.clearCookies();
+
+    await page.goto('/categories');
+    await expect(page).toHaveURL(/\/sign-in$/);
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+  });
+});

--- a/dashboard/e2e/category-delete-home.spec.ts
+++ b/dashboard/e2e/category-delete-home.spec.ts
@@ -5,36 +5,17 @@ import {
   cleanupE2eArtifacts,
   createE2eArtifacts,
 } from './helpers/artifacts';
+import {
+  adminCredentialsMissing,
+  apiBaseUrl,
+  apiSecret,
+  signInAsAdmin,
+} from './helpers/auth';
 
-const adminEmail =
-  process.env.AUTH_EMAIL ??
-  process.env.DASHBOARD_EMAIL ??
-  process.env.E2E_ADMIN_EMAIL;
-const adminPassword =
-  process.env.AUTH_PASSWORD ??
-  process.env.DASHBOARD_PASSWORD ??
-  process.env.E2E_ADMIN_PASSWORD;
-const apiSecret = process.env.API_SECRET ?? process.env.CLOUDINARY_API_SECRET;
-const apiBaseUrl = process.env.E2E_API_BASE_URL ?? 'http://localhost:3000';
-
-const missingEnv = !adminEmail || !adminPassword || !apiSecret;
-
-const getAdminToken = async (request: APIRequestContext) => {
-  const res = await request.post(`${apiBaseUrl}/api/auth/login`, {
-    data: { email: adminEmail, password: adminPassword },
-    headers: { 'content-type': 'application/json' },
-  });
-  expect(res.ok()).toBeTruthy();
-  const payload = (await res.json()) as { token?: string };
-  if (!payload.token) {
-    throw new Error('Missing token in /api/auth/login response');
-  }
-  return payload.token;
-};
+const missingEnv = adminCredentialsMissing || !apiSecret;
 
 const ensureHomeCategoryId = async (
-  request: APIRequestContext,
-  token: string
+  request: APIRequestContext
 ) => {
   const res = await request.get(`${apiBaseUrl}/api/categories`);
   expect(res.ok()).toBeTruthy();
@@ -44,10 +25,7 @@ const ensureHomeCategoryId = async (
 
   const createRes = await request.post(`${apiBaseUrl}/api/categories`, {
     data: { name: 'Home', description: 'Home' },
-    headers: {
-      'content-type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
+    headers: { 'content-type': 'application/json' },
   });
   expect(createRes.ok()).toBeTruthy();
   const created = (await createRes.json()) as { id: string };
@@ -112,54 +90,48 @@ const findImageIdByTitle = async (request: APIRequestContext, title: string) => 
 test.describe('Category delete keeps images in Home', () => {
   test.skip(missingEnv, 'Missing admin credentials or API_SECRET');
 
-  test('deleting a category does not orphan images from Home', async ({ request }) => {
+  test('deleting a category does not orphan images from Home', async ({ page }) => {
+    await signInAsAdmin(page);
+    const authRequest = page.request;
+
     const artifacts = createE2eArtifacts();
-    const token = await getAdminToken(request);
     const now = Date.now();
     const title = `E2E Delete ${now}`;
     const publicId = `e2e/delete/${now}-${Math.random().toString(16).slice(2)}`;
     artifacts.imagePublicIds.add(publicId);
 
     try {
-      const homeCategoryId = await ensureHomeCategoryId(request, token);
-      await sendWebhookImage(request, {
+      const homeCategoryId = await ensureHomeCategoryId(authRequest);
+      await sendWebhookImage(authRequest, {
         publicId,
         title,
       });
 
-      const imageId = await findImageIdByTitle(request, title);
+      const imageId = await findImageIdByTitle(authRequest, title);
       artifacts.imageIds.add(imageId);
 
-      const createCategoryRes = await request.post(`${apiBaseUrl}/api/categories`, {
+      const createCategoryRes = await authRequest.post(`${apiBaseUrl}/api/categories`, {
         data: { name: `E2E Delete Cat ${now}`, description: 'delete test' },
-        headers: {
-          'content-type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { 'content-type': 'application/json' },
       });
       expect(createCategoryRes.ok()).toBeTruthy();
       const category = (await createCategoryRes.json()) as { id: string };
       artifacts.categoryIds.add(category.id);
 
-      const attachRes = await request.post(
+      const attachRes = await authRequest.post(
         `${apiBaseUrl}/api/categories/${category.id}/images`,
         {
           data: { imageIds: [imageId] },
-          headers: {
-            'content-type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { 'content-type': 'application/json' },
         }
       );
       expect(attachRes.ok()).toBeTruthy();
 
-      const deleteRes = await request.delete(`${apiBaseUrl}/api/categories/${category.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const deleteRes = await authRequest.delete(`${apiBaseUrl}/api/categories/${category.id}`);
       expect(deleteRes.ok()).toBeTruthy();
       artifacts.categoryIds.delete(category.id);
 
-      const homeDetailRes = await request.get(
+      const homeDetailRes = await authRequest.get(
         `${apiBaseUrl}/api/categories/${homeCategoryId}`
       );
       expect(homeDetailRes.ok()).toBeTruthy();
@@ -168,8 +140,7 @@ test.describe('Category delete keeps images in Home', () => {
       expect(found).toBeTruthy();
     } finally {
       await cleanupE2eArtifacts({
-        request,
-        token,
+        request: authRequest,
         artifacts,
         apiBaseUrl,
       });

--- a/dashboard/e2e/category-order.spec.ts
+++ b/dashboard/e2e/category-order.spec.ts
@@ -1,56 +1,27 @@
 import crypto from 'crypto';
 import { expect, test } from '@playwright/test';
-import type { APIRequestContext, Page } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
 import {
   cleanupE2eArtifacts,
   createE2eArtifacts,
 } from './helpers/artifacts';
+import {
+  adminCredentialsMissing,
+  apiBaseUrl,
+  apiSecret,
+  signInAsAdmin,
+} from './helpers/auth';
 
-const adminEmail =
-  process.env.AUTH_EMAIL ??
-  process.env.DASHBOARD_EMAIL ??
-  process.env.E2E_ADMIN_EMAIL;
-const adminPassword =
-  process.env.AUTH_PASSWORD ??
-  process.env.DASHBOARD_PASSWORD ??
-  process.env.E2E_ADMIN_PASSWORD;
-const apiSecret = process.env.API_SECRET ?? process.env.CLOUDINARY_API_SECRET;
-const apiBaseUrl = process.env.E2E_API_BASE_URL ?? 'http://localhost:3000';
-
-const missingLoginEnv = !adminEmail || !adminPassword;
+const missingLoginEnv = adminCredentialsMissing;
 const missingWebhookEnv = missingLoginEnv || !apiSecret;
-
-const signIn = async (page: Page) => {
-  await page.goto('/sign-in');
-  await page.getByLabel('Email').fill(adminEmail!);
-  await page.getByLabel('Password').fill(adminPassword!);
-  await page.getByRole('button', { name: 'Sign in' }).click();
-};
-
-const getAdminToken = async (request: APIRequestContext) => {
-  const res = await request.post(`${apiBaseUrl}/api/auth/login`, {
-    data: { email: adminEmail, password: adminPassword },
-    headers: { 'content-type': 'application/json' },
-  });
-  expect(res.ok()).toBeTruthy();
-  const payload = (await res.json()) as { token?: string };
-  if (!payload.token) {
-    throw new Error('Missing token in /api/auth/login response');
-  }
-  return payload.token;
-};
 
 const createCategory = async (
   request: APIRequestContext,
-  token: string,
   name: string
 ) => {
   const res = await request.post(`${apiBaseUrl}/api/categories`, {
     data: { name, description: `E2E seed for ${name}` },
-    headers: {
-      'content-type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
+    headers: { 'content-type': 'application/json' },
   });
   expect(res.ok()).toBeTruthy();
   return await res.json();
@@ -136,25 +107,18 @@ const fetchCategoryDetail = async (
 test.describe('Category ordering', () => {
   test.skip(missingLoginEnv, 'Missing admin credentials');
 
-  test('can reorder categories and save', async ({ page, request }) => {
+  test('can reorder categories and save', async ({ page }) => {
+    await signInAsAdmin(page);
+    const authRequest = page.request;
+
     const artifacts = createE2eArtifacts();
     const now = Date.now();
-    const token = await getAdminToken(request);
     try {
-      const categoryA = await createCategory(
-        request,
-        token,
-        `E2E Order ${now} A`
-      );
+      const categoryA = await createCategory(authRequest, `E2E Order ${now} A`);
       artifacts.categoryIds.add(categoryA.id);
-      const categoryB = await createCategory(
-        request,
-        token,
-        `E2E Order ${now} B`
-      );
+      const categoryB = await createCategory(authRequest, `E2E Order ${now} B`);
       artifacts.categoryIds.add(categoryB.id);
 
-      await signIn(page);
       await page.goto('/categories/order');
 
       const rowA = page.getByRole('row', { name: new RegExp(categoryA.name) });
@@ -175,7 +139,7 @@ test.describe('Category ordering', () => {
 
       await expect
         .poll(async () => {
-          const table = (await fetchCategoryTable(request)) as Array<{
+          const table = (await fetchCategoryTable(authRequest)) as Array<{
             id: string;
             sequence: number | null;
           }>;
@@ -189,7 +153,7 @@ test.describe('Category ordering', () => {
         })
         .toBe(true);
 
-      const table = (await fetchCategoryTable(request)) as Array<{
+      const table = (await fetchCategoryTable(authRequest)) as Array<{
         id: string;
         sequence: number | null;
       }>;
@@ -204,8 +168,7 @@ test.describe('Category ordering', () => {
       expect(rowAfterB.sequence).toBeLessThan(rowAfterA.sequence);
     } finally {
       await cleanupE2eArtifacts({
-        request,
-        token,
+        request: authRequest,
         artifacts,
         apiBaseUrl,
       });
@@ -218,10 +181,11 @@ test.describe('Image ordering', () => {
 
   test('saves custom image order for home category', async ({
     page,
-    request,
   }) => {
+    await signInAsAdmin(page);
+    const authRequest = page.request;
+
     const artifacts = createE2eArtifacts();
-    const token = await getAdminToken(request);
     const now = Date.now();
     const titleA = `E2E Image ${now} A`;
     const titleB = `E2E Image ${now} B`;
@@ -231,18 +195,17 @@ test.describe('Image ordering', () => {
     artifacts.imagePublicIds.add(publicIdB);
 
     try {
-      await sendWebhookImage(request, {
+      await sendWebhookImage(authRequest, {
         publicId: publicIdA,
         title: titleA,
       });
-      await sendWebhookImage(request, {
+      await sendWebhookImage(authRequest, {
         publicId: publicIdB,
         title: titleB,
       });
 
-      const homeCategoryId = await fetchHomeCategoryId(request);
+      const homeCategoryId = await fetchHomeCategoryId(authRequest);
 
-      await signIn(page);
       await page.goto(`/categories/${homeCategoryId}/project-order`);
 
       const rowA = page.getByRole('listitem', { name: new RegExp(titleA) });
@@ -273,7 +236,7 @@ test.describe('Image ordering', () => {
 
       await expect
         .poll(async () => {
-          const detail = (await fetchCategoryDetail(request, homeCategoryId)) as {
+          const detail = (await fetchCategoryDetail(authRequest, homeCategoryId)) as {
             sortMode?: string | null;
           };
           return detail.sortMode;
@@ -282,7 +245,7 @@ test.describe('Image ordering', () => {
 
       await expect
         .poll(async () => {
-          const detail = (await fetchCategoryDetail(request, homeCategoryId)) as {
+          const detail = (await fetchCategoryDetail(authRequest, homeCategoryId)) as {
             images?: Array<{ title?: string | null; position?: number | null }>;
           };
           const moved = detail.images?.find((img) => img.title === movedTitle);
@@ -291,8 +254,7 @@ test.describe('Image ordering', () => {
         .toBe(movedFromPosition - 1);
     } finally {
       await cleanupE2eArtifacts({
-        request,
-        token,
+        request: authRequest,
         artifacts,
         apiBaseUrl,
       });

--- a/dashboard/e2e/cloudinary-webhook.spec.ts
+++ b/dashboard/e2e/cloudinary-webhook.spec.ts
@@ -1,46 +1,26 @@
 import crypto from 'crypto';
 import { test, expect } from '@playwright/test';
-import type { APIRequestContext } from '@playwright/test';
 import {
   cleanupE2eArtifacts,
   createE2eArtifacts,
 } from './helpers/artifacts';
+import {
+  adminCredentialsMissing,
+  apiBaseUrl,
+  apiSecret,
+  signInAsAdmin,
+} from './helpers/auth';
 
-const adminEmail =
-  process.env.AUTH_EMAIL ??
-  process.env.DASHBOARD_EMAIL ??
-  process.env.E2E_ADMIN_EMAIL;
-const adminPassword =
-  process.env.AUTH_PASSWORD ??
-  process.env.DASHBOARD_PASSWORD ??
-  process.env.E2E_ADMIN_PASSWORD;
-const apiSecret = process.env.API_SECRET ?? process.env.CLOUDINARY_API_SECRET;
-const apiBaseUrl = process.env.E2E_API_BASE_URL ?? 'http://localhost:3000';
-
-const missingEnv = !adminEmail || !adminPassword || !apiSecret;
-
-const getAdminToken = async (request: APIRequestContext) => {
-  const res = await request.post(`${apiBaseUrl}/api/auth/login`, {
-    data: { email: adminEmail, password: adminPassword },
-    headers: { 'content-type': 'application/json' },
-  });
-  expect(res.ok()).toBeTruthy();
-  const payload = (await res.json()) as { token?: string };
-  if (!payload.token) {
-    throw new Error('Missing token in /api/auth/login response');
-  }
-  return payload.token;
-};
+const missingEnv = adminCredentialsMissing || !apiSecret;
 
 test.describe('Cloudinary webhook round-trip', () => {
   test.skip(missingEnv, 'Missing admin credentials or API_SECRET');
 
-  test('webhook inserts image and shows in dashboard', async ({
-    page,
-    request,
-  }) => {
+  test('webhook inserts image and shows in dashboard', async ({ page }) => {
+    await signInAsAdmin(page);
+    const authRequest = page.request;
+
     const artifacts = createE2eArtifacts();
-    const token = await getAdminToken(request);
 
     const now = Date.now();
     const title = `E2E ${now}`;
@@ -68,7 +48,7 @@ test.describe('Cloudinary webhook round-trip', () => {
         .update(`${rawBody}${timestamp}${apiSecret}`)
         .digest('hex');
 
-      const webhookRes = await request.post(
+      const webhookRes = await authRequest.post(
         `${apiBaseUrl}/api/cloudinary/webhook`,
         {
           data: rawBody,
@@ -82,11 +62,6 @@ test.describe('Cloudinary webhook round-trip', () => {
 
       expect(webhookRes.ok()).toBeTruthy();
 
-      await page.goto('/sign-in');
-      await page.getByLabel('Email').fill(adminEmail!);
-      await page.getByLabel('Password').fill(adminPassword!);
-      await page.getByRole('button', { name: 'Sign in' }).click();
-
       await page.goto('/images');
       await page.getByPlaceholder('Search').fill(title);
       await page.waitForTimeout(1100);
@@ -94,8 +69,7 @@ test.describe('Cloudinary webhook round-trip', () => {
       await expect(page.getByRole('img', { name: title })).toBeVisible();
     } finally {
       await cleanupE2eArtifacts({
-        request,
-        token,
+        request: authRequest,
         artifacts,
         apiBaseUrl,
       });

--- a/dashboard/e2e/edit-image-category.spec.ts
+++ b/dashboard/e2e/edit-image-category.spec.ts
@@ -1,41 +1,16 @@
 import { expect, test } from '@playwright/test';
-import type { APIRequestContext, Page } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
 import {
   cleanupE2eArtifacts,
   createE2eArtifacts,
 } from './helpers/artifacts';
+import {
+  adminCredentialsMissing,
+  apiBaseUrl,
+  signInAsAdmin,
+} from './helpers/auth';
 
-const adminEmail =
-  process.env.AUTH_EMAIL ??
-  process.env.DASHBOARD_EMAIL ??
-  process.env.E2E_ADMIN_EMAIL;
-const adminPassword =
-  process.env.AUTH_PASSWORD ??
-  process.env.DASHBOARD_PASSWORD ??
-  process.env.E2E_ADMIN_PASSWORD;
-const apiBaseUrl = process.env.E2E_API_BASE_URL ?? 'http://localhost:3000';
-
-const missingEnv = !adminEmail || !adminPassword;
-
-const signIn = async (page: Page) => {
-  await page.goto('/sign-in');
-  await page.getByLabel('Email').fill(adminEmail!);
-  await page.getByLabel('Password').fill(adminPassword!);
-  await page.getByRole('button', { name: 'Sign in' }).click();
-};
-
-const getAdminToken = async (request: APIRequestContext) => {
-  const res = await request.post(`${apiBaseUrl}/api/auth/login`, {
-    data: { email: adminEmail, password: adminPassword },
-    headers: { 'content-type': 'application/json' },
-  });
-  expect(res.ok()).toBeTruthy();
-  const payload = (await res.json()) as { token?: string };
-  if (!payload.token) {
-    throw new Error('Missing token in /api/auth/login response');
-  }
-  return payload.token;
-};
+const missingEnv = adminCredentialsMissing;
 
 const fetchHomeCategoryId = async (request: APIRequestContext) => {
   const res = await request.get(`${apiBaseUrl}/api/categories`);
@@ -69,22 +44,20 @@ test.describe('Edit Image category', () => {
 
   test('can assign an image to a category and keep it in Home', async ({
     page,
-    request,
   }) => {
+    await signInAsAdmin(page);
+    const authRequest = page.request;
+
     const artifacts = createE2eArtifacts();
     const now = Date.now();
-    const token = await getAdminToken(request);
     try {
       const createCategory = async (suffix: string) => {
-        const res = await request.post(`${apiBaseUrl}/api/categories`, {
+        const res = await authRequest.post(`${apiBaseUrl}/api/categories`, {
           data: {
             name: `E2E Edit Cat ${now} ${suffix}`,
             description: 'edit-image-category',
           },
-          headers: {
-            'content-type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { 'content-type': 'application/json' },
         });
         expect(res.ok()).toBeTruthy();
         return (await res.json()) as { id: string; name: string };
@@ -98,7 +71,7 @@ test.describe('Edit Image category', () => {
       const title = `E2E Image Edit Cat ${now}`;
       const publicId = `e2e/edit-cat/${now}-${Math.random().toString(16).slice(2)}`;
       artifacts.imagePublicIds.add(publicId);
-      const fromCloudinaryRes = await request.post(
+      const fromCloudinaryRes = await authRequest.post(
         `${apiBaseUrl}/api/images/from-cloudinary`,
         {
           data: {
@@ -108,10 +81,7 @@ test.describe('Edit Image category', () => {
             width: 1200,
             height: 800,
           },
-          headers: {
-            'content-type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { 'content-type': 'application/json' },
         }
       );
       expect(fromCloudinaryRes.ok()).toBeTruthy();
@@ -121,7 +91,6 @@ test.describe('Edit Image category', () => {
       }
       artifacts.imageIds.add(createdImage.id);
 
-      await signIn(page);
       await page.goto(`/images/${createdImage.id}`);
 
       const categoriesField = page.locator('[aria-label="Categories"]').first();
@@ -140,21 +109,20 @@ test.describe('Edit Image category', () => {
       await page.getByRole('button', { name: 'Submit' }).click();
 
       await expect
-        .poll(() => categoryHasImageTitle(request, categoryA.id, title))
+        .poll(() => categoryHasImageTitle(authRequest, categoryA.id, title))
         .toBe(true);
 
       await expect
-        .poll(() => categoryHasImageTitle(request, categoryB.id, title))
+        .poll(() => categoryHasImageTitle(authRequest, categoryB.id, title))
         .toBe(true);
 
-      const homeId = await fetchHomeCategoryId(request);
+      const homeId = await fetchHomeCategoryId(authRequest);
       await expect
-        .poll(() => categoryHasImageTitle(request, homeId, title))
+        .poll(() => categoryHasImageTitle(authRequest, homeId, title))
         .toBe(true);
     } finally {
       await cleanupE2eArtifacts({
-        request,
-        token,
+        request: authRequest,
         artifacts,
         apiBaseUrl,
       });

--- a/dashboard/e2e/helpers/artifacts.ts
+++ b/dashboard/e2e/helpers/artifacts.ts
@@ -29,12 +29,10 @@ const resolveImageIdsByPublicId = async (
 
 export const cleanupE2eArtifacts = async ({
   request,
-  token,
   artifacts,
   apiBaseUrl,
 }: {
   request: APIRequestContext;
-  token: string;
   artifacts: E2eArtifacts;
   apiBaseUrl: string;
 }) => {
@@ -45,24 +43,16 @@ export const cleanupE2eArtifacts = async ({
   }
 
   for (const imageId of imageIds) {
-    const res = await request.delete(`${apiBaseUrl}/api/images/${imageId}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const res = await request.delete(`${apiBaseUrl}/api/images/${imageId}`);
     if (res.status() !== 404) {
       expect(res.ok()).toBeTruthy();
     }
   }
 
   for (const categoryId of artifacts.categoryIds) {
-    const res = await request.delete(
-      `${apiBaseUrl}/api/categories/${categoryId}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      }
-    );
+    const res = await request.delete(`${apiBaseUrl}/api/categories/${categoryId}`);
     if (res.status() !== 404) {
       expect(res.ok()).toBeTruthy();
     }
   }
 };
-

--- a/dashboard/e2e/helpers/auth.ts
+++ b/dashboard/e2e/helpers/auth.ts
@@ -1,0 +1,29 @@
+import { expect, type Page } from '@playwright/test';
+
+export const adminEmail =
+  process.env.E2E_ADMIN_EMAIL ??
+  process.env.AUTH_EMAIL ??
+  process.env.DASHBOARD_EMAIL;
+export const adminPassword =
+  process.env.E2E_ADMIN_PASSWORD ??
+  process.env.AUTH_PASSWORD ??
+  process.env.DASHBOARD_PASSWORD;
+export const apiBaseUrl = process.env.E2E_API_BASE_URL ?? 'http://localhost:3000';
+export const apiSecret = process.env.API_SECRET ?? process.env.CLOUDINARY_API_SECRET;
+
+export const adminCredentialsMissing = !adminEmail || !adminPassword;
+
+export const signInAsAdmin = async (page: Page) => {
+  if (!adminEmail || !adminPassword) {
+    throw new Error(
+      'Missing admin credentials: set E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD'
+    );
+  }
+
+  await page.goto('/sign-in');
+  await page.getByLabel('Email').fill(adminEmail);
+  await page.getByLabel('Password').fill(adminPassword);
+  await page.getByRole('button', { name: /sign in/i }).click();
+
+  await expect(page).not.toHaveURL(/\/sign-in$/);
+};

--- a/dashboard/e2e/upload-limit.spec.ts
+++ b/dashboard/e2e/upload-limit.spec.ts
@@ -1,29 +1,13 @@
 import { expect, test } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import { adminCredentialsMissing, signInAsAdmin } from './helpers/auth';
 
-const adminEmail =
-  process.env.AUTH_EMAIL ??
-  process.env.DASHBOARD_EMAIL ??
-  process.env.E2E_ADMIN_EMAIL;
-const adminPassword =
-  process.env.AUTH_PASSWORD ??
-  process.env.DASHBOARD_PASSWORD ??
-  process.env.E2E_ADMIN_PASSWORD;
-
-const missingEnv = !adminEmail || !adminPassword;
-
-const signIn = async (page: Page) => {
-  await page.goto('/sign-in');
-  await page.getByLabel('Email').fill(adminEmail!);
-  await page.getByLabel('Password').fill(adminPassword!);
-  await page.getByRole('button', { name: 'Sign in' }).click();
-};
+const missingEnv = adminCredentialsMissing;
 
 test.describe('Upload limit', () => {
   test.skip(missingEnv, 'Missing admin credentials');
 
   test('caps selected files at 10', async ({ page }) => {
-    await signIn(page);
+    await signInAsAdmin(page);
     await page.goto('/images/upload');
 
     const png = Buffer.from(

--- a/dashboard/src/auth.tsx
+++ b/dashboard/src/auth.tsx
@@ -1,17 +1,23 @@
 /* eslint-disable react-refresh/only-export-components */
 import type { ReactNode } from 'react';
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
-
-export const TOKEN_STORAGE_KEY = 'takashi.dashboard.token';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  AuthSessionError,
+  getSessionUser,
+  signInWithEmail,
+  signOutSession,
+  type AuthUser,
+} from '@/lib/api';
 
 export type AuthContextValue = {
   state: {
-    token: string | null;
+    user: AuthUser | null;
+    status: 'loading' | 'authenticated' | 'unauthenticated';
   };
   actions: {
-    getToken: () => Promise<string | null>;
-    setToken: (token: string) => void;
-    signOut: () => void;
+    signIn: (credentials: { email: string; password: string }) => Promise<AuthUser>;
+    signOut: () => Promise<void>;
+    refresh: () => Promise<AuthUser | null>;
   };
   meta: {
     isSignedIn: boolean;
@@ -20,33 +26,56 @@ export type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-const readStoredToken = () => {
-  if (typeof window === 'undefined') return null;
-  return window.localStorage.getItem(TOKEN_STORAGE_KEY);
-};
-
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [token, setTokenState] = useState<string | null>(readStoredToken);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [status, setStatus] = useState<'loading' | 'authenticated' | 'unauthenticated'>('loading');
 
-  const setToken = useCallback((nextToken: string) => {
-    setTokenState(nextToken);
-    window.localStorage.setItem(TOKEN_STORAGE_KEY, nextToken);
+  const refresh = useCallback(async () => {
+    try {
+      const nextUser = await getSessionUser();
+      setUser(nextUser);
+      setStatus('authenticated');
+      return nextUser;
+    } catch (error) {
+      setUser(null);
+      setStatus('unauthenticated');
+      if (error instanceof AuthSessionError && error.status === 403) {
+        throw error;
+      }
+      return null;
+    }
   }, []);
 
-  const signOut = useCallback(() => {
-    setTokenState(null);
-    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  const signIn = useCallback(
+    async ({ email, password }: { email: string; password: string }) => {
+      const nextUser = await signInWithEmail({ email, password });
+      setUser(nextUser);
+      setStatus('authenticated');
+      return nextUser;
+    },
+    []
+  );
+
+  const signOut = useCallback(async () => {
+    try {
+      await signOutSession();
+    } finally {
+      setUser(null);
+      setStatus('unauthenticated');
+    }
   }, []);
 
-  const getToken = useCallback(async () => token, [token]);
+  useEffect(() => {
+    void refresh().catch(() => undefined);
+  }, [refresh]);
 
   const value = useMemo(
     () => ({
-      state: { token },
-      actions: { getToken, setToken, signOut },
-      meta: { isSignedIn: Boolean(token) },
+      state: { user, status },
+      actions: { signIn, signOut, refresh },
+      meta: { isSignedIn: status === 'authenticated' && user !== null },
     }),
-    [getToken, signOut, setToken, token]
+    [refresh, signIn, signOut, status, user]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/dashboard/src/components/app-sidebar.tsx
+++ b/dashboard/src/components/app-sidebar.tsx
@@ -79,8 +79,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { meta, actions } = useAuth();
   const navigate = useNavigate();
 
-  const handleSignOut = () => {
-    actions.signOut();
+  const handleSignOut = async () => {
+    await actions.signOut();
     navigate({ to: '/sign-in' });
   };
   return (

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -2,29 +2,14 @@ import type { AppType } from '@server/index';
 import { hc } from 'hono/client';
 import { QueryClient } from '@tanstack/react-query';
 import { queryOptions } from '@tanstack/react-query';
-import { TOKEN_STORAGE_KEY } from '@/auth';
-import { assertOk } from './http';
+import { assertOk, readErrorMessage } from './http';
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
 
 const authedFetch: typeof fetch = async (input, init) => {
-  if (typeof window === 'undefined') {
-    return fetch(input, init);
-  }
-
-  const token = window.localStorage.getItem(TOKEN_STORAGE_KEY);
-  if (!token) {
-    return fetch(input, init);
-  }
-
-  const headers = new Headers(init?.headers ?? undefined);
-  if (!headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${token}`);
-  }
-
-  return fetch(input, {
+  return await fetch(input, {
     ...init,
-    headers,
+    credentials: init?.credentials ?? 'include',
   });
 };
 
@@ -32,17 +17,96 @@ export const client = hc<AppType>(apiBaseUrl, { fetch: authedFetch });
 
 export const queryClient = new QueryClient();
 
-export async function checkAuth(token: string) {
-  const res = await client.api.auth.$get(
-    {},
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+export type AuthUser = {
+  id: string;
+  email: string;
+  role: string;
+};
+
+export class AuthSessionError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+type SessionPayload = {
+  sub?: unknown;
+  role?: unknown;
+  user?: {
+    id?: unknown;
+    email?: unknown;
+    role?: unknown;
+  };
+};
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0;
+
+const toApiUrl = (path: string) => (apiBaseUrl ? `${apiBaseUrl}${path}` : path);
+
+const normalizeSessionUser = (payload: SessionPayload): AuthUser => {
+  const sessionUser = payload.user;
+  if (sessionUser) {
+    const id = sessionUser.id;
+    const email = sessionUser.email;
+    const role = sessionUser.role ?? payload.role;
+    if (
+      isNonEmptyString(id) &&
+      isNonEmptyString(email) &&
+      isNonEmptyString(role)
+    ) {
+      return { id, email, role };
     }
-  );
-  await assertOk(res);
-  return await res.json();
+  }
+
+  const sub = payload.sub;
+  const role = payload.role;
+  if (isNonEmptyString(sub) && isNonEmptyString(role)) {
+    return { id: sub, email: sub, role };
+  }
+
+  throw new Error('Invalid session response');
+};
+
+export async function getSessionUser() {
+  const res = await client.api.auth.$get();
+  if (!res.ok) {
+    throw new AuthSessionError(await readErrorMessage(res), res.status);
+  }
+  const payload = (await res.json()) as SessionPayload;
+  return normalizeSessionUser(payload);
+}
+
+export async function signInWithEmail({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}) {
+  const res = await fetch(toApiUrl('/api/auth/sign-in/email'), {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorMessage(res));
+  }
+  return await getSessionUser();
+}
+
+export async function signOutSession() {
+  const res = await fetch(toApiUrl('/api/auth/sign-out'), {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok && res.status !== 401) {
+    throw new Error(await readErrorMessage(res));
+  }
 }
 
 async function getDashboardData() {

--- a/dashboard/src/routes/_auth.tsx
+++ b/dashboard/src/routes/_auth.tsx
@@ -23,26 +23,40 @@ import {
 } from '@/components/ui/sidebar';
 
 import { capitalize } from '@/lib/utils';
-import { checkAuth } from '@/lib/api';
+import { AuthSessionError } from '@/lib/api';
 
 export const Route = createFileRoute('/_auth')({
   beforeLoad: async ({ context }) => {
-    const token = await context.auth.actions.getToken();
-    if (!token) {
+    try {
+      const queryClient = context.queryClient;
+      const user = await queryClient.fetchQuery({
+        queryKey: ['auth', 'session'],
+        queryFn: context.auth.actions.refresh,
+        staleTime: 0,
+      });
+
+      if (!user) {
+        throw redirect({
+          to: '/sign-in',
+        });
+      }
+
+      if (user.role !== 'admin') {
+        throw redirect({
+          to: '/unauthorized',
+        });
+      }
+    } catch (error) {
+      if (error instanceof AuthSessionError && error.status === 403) {
+        throw redirect({
+          to: '/unauthorized',
+        });
+      }
+      if (error && typeof error === 'object' && 'to' in error) {
+        throw error;
+      }
       throw redirect({
         to: '/sign-in',
-      });
-    }
-    const queryClient = context.queryClient;
-    try {
-      await queryClient.fetchQuery({
-        queryKey: ['isAuthenticated'],
-        queryFn: async () => await checkAuth(token),
-        staleTime: Infinity,
-      });
-    } catch {
-      throw redirect({
-        to: '/unauthorized',
       });
     }
   },

--- a/dashboard/src/routes/sign-in.tsx
+++ b/dashboard/src/routes/sign-in.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/auth';
-import { readErrorMessage } from '@/lib/http';
 import { toast } from 'sonner';
 
 export const Route = createFileRoute('/sign-in')({
@@ -31,25 +30,16 @@ function RouteComponent() {
     setError('');
     setIsSubmitting(true);
     try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      });
-      if (!res.ok) {
-        throw new Error(await readErrorMessage(res));
-      }
-      const payload = (await res.json()) as { token?: string };
-      if (!payload.token) {
-        throw new Error('Missing token in response');
-      }
-      actions.setToken(payload.token);
+      await actions.signIn({ email, password });
       navigate({ to: '/' });
     } catch (err) {
       const rawMessage =
         err instanceof Error ? err.message : 'Unable to sign in';
+      const normalizedMessage = rawMessage.toLowerCase();
       const message =
-        rawMessage === 'Invalid credentials'
+        normalizedMessage.includes('invalid credentials') ||
+        normalizedMessage.includes('invalid email or password') ||
+        normalizedMessage.includes('incorrect email or password')
           ? 'Incorrect email or password.'
           : rawMessage;
       setError(message);

--- a/dashboard/src/routes/unauthorized.tsx
+++ b/dashboard/src/routes/unauthorized.tsx
@@ -10,8 +10,8 @@ function RouteComponent() {
   const { meta, actions } = useAuth();
   const navigate = useNavigate();
 
-  const handleSignOut = () => {
-    actions.signOut();
+  const handleSignOut = async () => {
+    await actions.signOut();
     navigate({ to: '/sign-in' });
   };
   return (


### PR DESCRIPTION
## Summary
- migrate dashboard auth client flow to Better Auth session endpoints
- update dashboard e2e specs to sign in through /sign-in and use session cookies
- add shared e2e auth helper + session guard regression spec
- update dashboard README with required e2e env vars

## Validation
- pnpm lint
- pnpm typecheck
- pnpm -C dashboard test:e2e (7 skipped under current env gating)